### PR TITLE
Piper/add get next node helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Grove provides indexed storage for ordered data such that it can be efficiently
 queried.
 
-You can deploy grove yourself, or use the version deployed at `0x6b07cb54be50bc040cca0360ec792d7b5609f4db`
+You can deploy grove yourself, or use the version deployed at `0x7d7ce4e2cdfea812b33f48f419860b91cf9a141d`
 
 If you would like to verify the source, it was compiled using version
-``0.1.3-1736fe80`` of the ``solc`` compiler with the ``--optimize`` flag turned
+`0.1.3-1736fe80` of the `solc` compiler with the `--optimize` flag turned
 on.
 
 

--- a/contracts/Grove.sol
+++ b/contracts/Grove.sol
@@ -76,6 +76,45 @@ contract Grove {
             return node_lookup[nodeId].right;
         }
 
+        function getNextNode(bytes32 nodeId) constant returns (bytes32) {
+            var currentNode = node_lookup[nodeId];
+            Node child;
+
+            if (currentNode.right != 0x0) {
+                // Trace right to earliest child in right tree.
+                child = node_lookup[currentNode.right];
+
+                while (child.left != 0) {
+                    child = node_lookup[child.left];
+                }
+                return child.nodeId;
+            }
+
+            if (currentNode.parent != 0x0) {
+                // if the node is the left child of it's parent, then the
+                // parent is the next one.
+                var parent = node_lookup[currentNode.parent];
+                child = currentNode;
+
+                while (true) {
+                    if (parent.left == child.nodeId) {
+                        return parent.nodeId;
+                    }
+
+                    if (parent.parent == 0x0) {
+                        break;
+                    }
+                    child = parent;
+                    parent = node_lookup[parent.parent];
+                }
+
+                // Now we need to trace all the way up checking to see if any parent is the 
+            }
+
+            // This is the final node.
+            return 0x0;
+        }
+
         function insert(bytes32 indexName, bytes32 id, int value) public {
                 bytes32 indexId = getIndexId(msg.sender, indexName);
                 if (index_lookup[indexId] == 0x0) {

--- a/contracts/Grove.sol
+++ b/contracts/Grove.sol
@@ -76,8 +76,18 @@ contract Grove {
             return node_lookup[nodeId].right;
         }
 
+        function getPreviousNode(bytes32 nodeId) constant returns (bytes32) {
+            // TODO
+        }
+
         function getNextNode(bytes32 nodeId) constant returns (bytes32) {
             var currentNode = node_lookup[nodeId];
+
+            if (currentNode.nodeId == 0x0) {
+                // Unknown node, just return 0x0;
+                return 0x0;
+            }
+
             Node child;
 
             if (currentNode.right != 0x0) {

--- a/contracts/Grove.sol
+++ b/contracts/Grove.sol
@@ -172,12 +172,14 @@ contract Grove {
                 }
                 bytes32 nodeId = getNodeId(indexId, id);
 
-                if (node_lookup[nodeId].id == id) {
-                    // A node with this id already exists.
-                    //
-                    // TODO: When deletion is supported, we can delete the
-                    // current node and then re-insert it.
-                    return;
+                if (node_lookup[nodeId].nodeId == nodeId) {
+                    // A node with this id already exists.  If the value is
+                    // the same, then just return early, otherwise, remove it
+                    // and reinsert it.
+                    if (node_lookup[nodeId].value == value) {
+                        return;
+                    }
+                    remove(indexName, id);
                 }
 
                 int balanceFactor;

--- a/contracts/api.sol
+++ b/contracts/api.sol
@@ -19,8 +19,16 @@ contract GroveAPI {
         function getNodeRightChild(bytes32 nodeId) constant returns (bytes32);
 
         /*
+         *  Traversal
+         */
+        function getNextNode(bytes32 nodeId) constant returns (bytes32);
+        function getPreviousNode(bytes32 nodeId) constant returns (bytes32);
+
+        /*
          *  Insert and Query API
          */
         function insert(bytes32 indexName, bytes32 id, int value) public;
         function query(bytes32 indexId, bytes2 operator, int value) public returns (bytes32);
+        function exists(bytes32 indexId, bytes32 id) constant returns (bool);
+        function remove(bytes32 indexName, bytes32 id) public;
 }

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,6 +15,7 @@ has an id which can be computed as ``sha3(ownerAddress, indexName)``.
 You can also use the ``getIndexId(address ownerAddress, bytes32 indexName)``
 function to compute this for you.
 
+
 Nodes
 -----
 
@@ -40,8 +41,9 @@ Grove, you must be able to provide a unique identifier for that data element,
 as well as an integer value that can be used to order the data element with
 respect to the other elements.
 
-Node API
-^^^^^^^^
+
+Node Properties
+^^^^^^^^^^^^^^^
 
 * **function getIndexName(bytes32 indexId) constant returns (bytes32)**
 
@@ -79,6 +81,21 @@ Node API
 
   Returns the right child of the node.
 
+
+Tree Traversal
+^^^^^^^^^^^^^^
+
+* **function getNextNode(bytes32 nodeId) constant returns (bytes32)**
+
+  Returns the node ID for the next sequential node in the index.  Returns 0x0
+  if there is not next node.
+
+* **function getPreviousNode(bytes32 nodeId) constant returns (bytes32)**
+
+  Returns the node ID for the previous sequential node in the index.  Returns
+  0x0 if there is no previous node.
+
+
 Insertion
 ^^^^^^^^^
 
@@ -91,6 +108,28 @@ You can use the ``insert`` function insert a new piece of data into the index.
 * **id:** The unique identifier for this data.
 * **value (int):** The value that can be used to order this node with respect
   to the other nodes.
+
+.. note::
+
+    If a node with the given **id** is already present in the index, then the 
+
+
+Removal (deletion)
+^^^^^^^^^^^^^^^^^^
+
+**function remove(bytes32 indexName, bytes32 id) public**
+
+You can use the ``remove`` function to remove an **id** from the index.
+
+
+Existence
+^^^^^^^^^
+
+**function exists(bytes32 indexId, bytes32 id) public returns (bool)**
+
+You can use the ``exists`` function to query whether an **id** is present
+within a given index.
+
 
 Querying
 ^^^^^^^^
@@ -143,10 +182,18 @@ natively.
         function getNodeRightChild(bytes32 nodeId) constant returns (bytes32);
 
         /*
+         *  Traversal
+         */
+        function getNextNode(bytes32 nodeId) constant returns (bytes32);
+        function getPreviousNode(bytes32 nodeId) constant returns (bytes32);
+
+        /*
          *  Insert and Query API
          */
         function insert(bytes32 indexName, bytes32 id, int value) public;
         function query(bytes32 indexId, bytes2 operator, int value) public returns (bytes32);
+        function exists(bytes32 indexId, bytes32 id) constant returns (bool);
+        function remove(bytes32 indexName, bytes32 id) public;
     }
 
 Contract ABI
@@ -156,4 +203,4 @@ The contract can be accessed via web3.js with
 
 .. code-block:: javascript
 
-    var Gove = web3.eth.contract([{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeLeftChild","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"},{"name":"id","type":"bytes32"}],"name":"getNodeId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeValue","outputs":[{"name":"","type":"int256"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeRightChild","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":false,"inputs":[{"name":"indexName","type":"bytes32"},{"name":"id","type":"bytes32"},{"name":"value","type":"int256"}],"name":"insert","outputs":[],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeParent","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"}],"name":"getIndexName","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeIndexId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeHeight","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"}],"name":"getIndexRoot","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"owner","type":"address"},{"name":"indexName","type":"bytes32"}],"name":"getIndexId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":false,"inputs":[{"name":"indexId","type":"bytes32"},{"name":"operator","type":"bytes2"},{"name":"value","type":"int256"}],"name":"query","outputs":[{"name":"","type":"bytes32"}],"type":"function"}]).at(0x6b07cb54be50bc040cca0360ec792d7b5609f4db);
+    var Grove = web3.eth.contract([{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeLeftChild","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getPreviousNode","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"},{"name":"id","type":"bytes32"}],"name":"getNodeId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeValue","outputs":[{"name":"","type":"int256"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeRightChild","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"},{"name":"id","type":"bytes32"}],"name":"exists","outputs":[{"name":"","type":"bool"}],"type":"function"},{"constant":false,"inputs":[{"name":"indexName","type":"bytes32"},{"name":"id","type":"bytes32"},{"name":"value","type":"int256"}],"name":"insert","outputs":[],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeParent","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"}],"name":"getIndexName","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeIndexId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNextNode","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":false,"inputs":[{"name":"indexName","type":"bytes32"},{"name":"id","type":"bytes32"}],"name":"remove","outputs":[],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeHeight","outputs":[{"name":"","type":"uint256"}],"type":"function"},{"constant":true,"inputs":[{"name":"nodeId","type":"bytes32"}],"name":"getNodeId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"indexId","type":"bytes32"}],"name":"getIndexRoot","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":true,"inputs":[{"name":"owner","type":"address"},{"name":"indexName","type":"bytes32"}],"name":"getIndexId","outputs":[{"name":"","type":"bytes32"}],"type":"function"},{"constant":false,"inputs":[{"name":"indexId","type":"bytes32"},{"name":"operator","type":"bytes2"},{"name":"value","type":"int256"}],"name":"query","outputs":[{"name":"","type":"bytes32"}],"type":"function"}]).at(0x7d7ce4e2cdfea812b33f48f419860b91cf9a141d);

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,6 @@ the source, it was compiled using version ``0.1.3-1736fe80`` of the ``solc``
 compiler with the ``--optimize`` flag turned on.
 
 
-
 .. toctree::
    intro
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ The current implementation uses an AVL tree for storage which has on average
 ``O(log n)`` time complexity for inserts and lookups.
 
 The Grove contract can be accessed at
-``0x6b07cb54be50bc040cca0360ec792d7b5609f4db``.  If you would like to verify
+``0x7d7ce4e2cdfea812b33f48f419860b91cf9a141d``.  If you would like to verify
 the source, it was compiled using version ``0.1.3-1736fe80`` of the ``solc``
 compiler with the ``--optimize`` flag turned on.
 

--- a/tests/balancing/test_node_deletion.py
+++ b/tests/balancing/test_node_deletion.py
@@ -1,0 +1,195 @@
+import pytest
+
+import random
+
+
+tree_nodes = (
+    ('a', 8),
+    ('b', 6),
+    ('c', 7),
+    ('d', 10),
+    ('e', 2),
+    ('f', 12),
+    ('g', 3),
+    ('h', 15),
+    ('i', 13),
+    ('j', 5),
+    ('k', 19),
+    ('l', 11),
+    ('m', 17),
+    ('n', 0),
+    ('o', 4),
+    ('p', 14),
+    ('q', 18),
+    ('r', 9),
+    ('s', 16),
+    ('t', 1),
+)
+
+
+@pytest.mark.parametrize(
+    'ids_to_remove,expected_states',
+    (
+        # id, value, parent, left, right, height
+        # Leaf Nodes
+        (
+            ['n'], {
+                ('t', 1, 'g', None, 'e', 2),
+            }
+        ),
+        (
+            ['l'], {
+                ('f', 12, 'd', None, None, 1),
+            }
+        ),
+        (
+            ['q'], {
+                ('k', 19, 'm', None, None, 1),
+            }
+        ),
+        (
+            ['b'], {
+                ('j', 5, 'g', 'o', None, 2),
+            }
+        ),
+        # One from bottom.
+        (
+            ['t'], {
+                ('n', 0, 'g', None, 'e', 2),
+                ('e', 2, 'n', None, None, 1),
+                ('g', 3, 'c', 'n', 'j', 3),
+            }
+        ),
+        (
+            ['a'], {
+                ('r', 9, 'd', None, None, 1),
+                ('d', 10, 'i', 'r', 'f', 3),
+            }
+        ),
+        (
+            ['a', 'r'], {
+                ('l', 11, 'i', 'd', 'f', 2),
+                ('d', 10, 'l', None, None, 1),
+                ('f', 12, 'l', None, None, 1),
+                ('i', 13, 'c', 'l', 'm', 4),
+            }
+        ),
+        (
+            ['f'], {
+                ('l', 11, 'd', None, None, 1),
+                ('d', 10, 'i', 'a', 'l', 3),
+            }
+        ),
+        (
+            ['f', 'l'], {
+                ('r', 9, 'i', 'a', 'd', 2),
+                ('a', 8, 'r', None, None, 1),
+                ('d', 10, 'r', None, None, 1),
+                ('i', 13, 'c', 'r', 'm', 4),
+            }
+        ),
+        # Mid tree
+        (
+            ['g'], {
+                ('e', 2, 'c', 't', 'j', 3),
+                ('t', 1, 'e', 'n', None, 2),
+                ('j', 5, 'e', 'o', 'b', 2),
+                ('c', 7, None, 'e', 'i', 5),
+            }
+        ),
+        (
+            ['i'], {
+                ('f', 12, 'c', 'd', 'm', 4),
+                ('d', 10, 'f', 'a', 'l', 3),
+                ('l', 11, 'd', None, None, 1),
+                ('m', 17, 'f', 'h', 'k', 3),
+                ('c', 7, None, 'g', 'f', 5),
+            }
+        ),
+        # Root
+        (
+            ['c'], {
+                ('b', 6, None, 'g', 'i', 5),
+                ('j', 5, 'g', 'o', None, 2),
+                ('g', 3, 'b', 't', 'j', 3),
+                ('i', 13, 'b', 'd', 'm', 4),
+            }
+        ),
+    )
+#tree_nodes = (
+#    ('a', 8),
+#    ('b', 6),
+#    ('c', 7),
+#    ('d', 10),
+#    ('e', 2),
+#    ('f', 12),
+#    ('g', 3),
+#    ('h', 15),
+#    ('i', 13),
+#    ('j', 5),
+#    ('k', 19),
+#    ('l', 11),
+#    ('m', 17),
+#    ('n', 0),
+#    ('o', 4),
+#    ('p', 14),
+#    ('q', 18),
+#    ('r', 9),
+#    ('s', 16),
+#    ('t', 1),
+#)
+)
+def test_removing_nodes(deployed_contracts, ids_to_remove, expected_states):
+    index_name = "test-{0}".format(''.join(ids_to_remove))
+
+    grove = deployed_contracts.Grove
+
+    for _id, value in tree_nodes:
+        grove.insert(index_name, _id, value)
+
+    def get_id(node_id):
+        if node_id is None:
+            return None
+        return grove.getNodeId.call(node_id)
+
+    index_id = grove.getIndexId(grove._meta.rpc_client.get_coinbase(), index_name)
+
+    for _id in ids_to_remove:
+        node_id = grove.getNodeId(index_id, _id)
+        assert grove.exists(index_id, _id) is True
+        grove.remove(index_name, _id)
+        assert grove.exists(index_id, _id) is False
+
+    actual_states = set()
+
+    for _id, _, _, _, _, _ in expected_states:
+        node_id = grove.getNodeId(index_id, _id)
+        value = grove.getNodeValue(node_id)
+        parent = get_id(grove.getNodeParent(node_id))
+        left = get_id(grove.getNodeLeftChild(node_id))
+        right = get_id(grove.getNodeRightChild(node_id))
+        height = grove.getNodeHeight(node_id)
+
+        actual_states.add((_id, value, parent, left, right, height))
+
+    assert expected_states == actual_states
+
+
+def test_deleting_sets_new_root(deployed_contracts):
+    grove = deployed_contracts.Grove
+
+    index_name = "test-root_deletion"
+    index_id = grove.getIndexId(grove._meta.rpc_client.get_coinbase(), index_name)
+
+    grove.insert(index_name, 'a', 2)
+    grove.insert(index_name, 'b', 1)
+    grove.insert(index_name, 'c', 3)
+
+    node_a_id = grove.getNodeId(index_id, 'a')
+    node_b_id = grove.getNodeId(index_id, 'b')
+
+    assert grove.getIndexRoot(index_id) == node_a_id
+
+    grove.remove(index_name, 'a')
+
+    assert grove.getIndexRoot(index_id) == node_b_id

--- a/tests/navigation/test_get_next_node.py
+++ b/tests/navigation/test_get_next_node.py
@@ -1,0 +1,88 @@
+import pytest
+
+
+tree_nodes = (
+    ('a', 18),
+    ('b', 0),
+    ('c', 7),
+    ('d', 11),
+    ('e', 16),
+    ('f', 3),
+    ('g', 16),
+    ('h', 17),
+    ('i', 17),
+    ('j', 18),
+    ('k', 12),
+    ('l', 3),
+    ('m', 4),
+    ('n', 6),
+    ('o', 11),
+    ('p', 5),
+    ('q', 12),
+    ('r', 1),
+    ('s', 1),
+    ('t', 16),
+    ('u', 14),
+    ('v', 3),
+    ('w', 7),
+    ('x', 13),
+    ('y', 6),
+    ('z', 17),
+)
+
+@pytest.fixture(scope="module")
+def big_tree(deployed_contracts):
+    grove = deployed_contracts.Grove
+
+    for _id, value in tree_nodes:
+        grove.insert('test', _id, value)
+    return grove
+
+
+@pytest.mark.parametrize(
+    '_id,next_id',
+    (
+        ('b', 'r'),
+        ('r', 's'),
+        ('s', 'f'),
+        ('f', 'l'),
+        ('l', 'v'),
+        ('v', 'm'),
+        ('m', 'p'),
+        ('p', 'n'),
+        ('n', 'y'),
+        ('y', 'c'),
+        ('c', 'w'),
+        ('w', 'd'),
+        ('d', 'o'),
+        ('o', 'k'),
+        ('k', 'q'),
+        ('q', 'x'),
+        ('x', 'u'),
+        ('u', 'e'),
+        ('e', 'g'),
+        ('g', 't'),
+        ('t', 'h'),
+        ('h', 'i'),
+        ('i', 'z'),
+        ('z', 'a'),
+        ('a', 'j'),
+        ('j', None),
+    )
+)
+def test_tree_querying(big_tree, _id, next_id):
+    def get_val(node_id):
+        if node_id is None:
+            return None
+        return big_tree.getNodeValue.call(node_id)
+
+    index_id = big_tree.getIndexId(big_tree._meta.rpc_client.get_coinbase(), "test")
+
+    node_id = big_tree.getNodeId(index_id, _id)
+    next_node_id = big_tree.getNextNode.call(node_id)
+    if next_id is None:
+        assert next_node_id is None
+    else:
+        actual_next_id = big_tree.getNodeId(next_node_id)
+
+        assert next_id == actual_next_id

--- a/tests/navigation/test_get_next_node.py
+++ b/tests/navigation/test_get_next_node.py
@@ -70,7 +70,7 @@ def big_tree(deployed_contracts):
         ('j', None),
     )
 )
-def test_tree_querying(big_tree, _id, next_id):
+def test_getting_next_node(big_tree, _id, next_id):
     def get_val(node_id):
         if node_id is None:
             return None
@@ -86,3 +86,52 @@ def test_tree_querying(big_tree, _id, next_id):
         actual_next_id = big_tree.getNodeId(next_node_id)
 
         assert next_id == actual_next_id
+
+
+@pytest.mark.parametrize(
+    '_id,previous_id',
+    (
+        ('b', None),
+        ('r', 'b'),
+        ('s', 'r'),
+        ('f', 's'),
+        ('l', 'f'),
+        ('v', 'l'),
+        ('m', 'v'),
+        ('p', 'm'),
+        ('n', 'p'),
+        ('y', 'n'),
+        ('c', 'y'),
+        ('w', 'c'),
+        ('d', 'w'),
+        ('o', 'd'),
+        ('k', 'o'),
+        ('q', 'k'),
+        ('x', 'q'),
+        ('u', 'x'),
+        ('e', 'u'),
+        ('g', 'e'),
+        ('t', 'g'),
+        ('h', 't'),
+        ('i', 'h'),
+        ('z', 'i'),
+        ('a', 'z'),
+        ('j', 'a'),
+    )
+)
+def test_getting_previous_node(big_tree, _id, previous_id):
+    def get_val(node_id):
+        if node_id is None:
+            return None
+        return big_tree.getNodeValue.call(node_id)
+
+    index_id = big_tree.getIndexId(big_tree._meta.rpc_client.get_coinbase(), "test")
+
+    node_id = big_tree.getNodeId(index_id, _id)
+    previous_node_id = big_tree.getPreviousNode.call(node_id)
+    if previous_id is None:
+        assert previous_node_id is None
+    else:
+        actual_previous_id = big_tree.getNodeId(previous_node_id)
+
+        assert previous_id == actual_previous_id

--- a/tests/query/test_exists_querying.py
+++ b/tests/query/test_exists_querying.py
@@ -1,0 +1,60 @@
+import pytest
+
+
+tree_nodes = (
+    ('a', 18),
+    ('b', 0),
+    ('c', 7),
+    ('d', 11),
+    ('e', 16),
+    ('f', 3),
+    ('g', 16),
+    ('h', 17),
+    ('i', 17),
+    ('j', 18),
+    ('k', 12),
+    ('l', 3),
+    ('m', 4),
+    ('n', 6),
+    ('o', 11),
+    ('p', 5),
+    ('q', 12),
+    ('r', 1),
+    ('s', 1),
+    ('t', 16),
+    ('u', 14),
+    ('v', 3),
+    ('w', 7),
+    ('x', 13),
+    ('y', 6),
+    ('z', 17),
+)
+
+
+def test_exists_query(deployed_contracts):
+    grove = deployed_contracts.Grove
+    index_id = grove.getIndexId(grove._meta.rpc_client.get_coinbase(), "test")
+
+    for _id, value in tree_nodes:
+        assert grove.exists(index_id, _id) is False
+
+        grove.insert('test', _id, value)
+
+        assert grove.exists(index_id, _id) is True
+
+    # Make sure it still registers as having all of the nodes.
+    for _id, _ in tree_nodes:
+        assert grove.exists(index_id, _id) is True
+
+    # Sanity check
+    for _id in ('aa', 'tsra', 'arst', 'bb', 'cc'):
+        assert grove.exists(index_id, _id) is False
+
+
+def test_exists_query_special_case(deployed_contracts):
+    grove = deployed_contracts.Grove
+    index_id = grove.getIndexId(grove._meta.rpc_client.get_coinbase(), "test")
+
+    grove.insert('test', 'key', 1234)
+
+    assert grove.exists(index_id, '') is False


### PR DESCRIPTION
Adds two helper functions `getNextNode` and `getPreviousNode` (not implemented yet) which help with the complexity of trying to iterate through the tree.
