### PR TITLE
Modernize Solidity

### DIFF
--- a/contracts/Grove.sol
+++ b/contracts/Grove.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.18;
+
 // Grove v0.3
 import "libraries/GroveLib.sol";
 
@@ -17,18 +19,18 @@ contract Grove {
         mapping (bytes32 => bytes32) node_to_index;
         mapping (bytes32 => bytes32) node_id_lookup;
 
-        /// @notice Computes the id for a Grove index which is sha3(owner, indexName)
+        /// @notice Computes the id for a Grove index which is keccak256(owner, indexName)
         /// @param owner The address of the index owner.
         /// @param indexName The name of the index.
-        function computeIndexId(address owner, bytes32 indexName) constant returns (bytes32) {
-                return sha3(owner, indexName);
+        function computeIndexId(address owner, bytes32 indexName) public pure returns (bytes32) {
+                return keccak256(owner, indexName);
         }
 
-        /// @notice Computes the id for a node in a given Grove index which is sha3(indexId, id)
+        /// @notice Computes the id for a node in a given Grove index which is keccak256(indexId, id)
         /// @param indexId The id for the index the node belongs to.
         /// @param id The unique identifier for the data this node represents.
-        function computeNodeId(bytes32 indexId, bytes32 id) constant returns (bytes32) {
-                return sha3(indexId, id);
+        function computeNodeId(bytes32 indexId, bytes32 id) public pure returns (bytes32) {
+                return keccak256(indexId, id);
         }
 
         /*
@@ -36,43 +38,43 @@ contract Grove {
          */
         /// @notice Retrieves the id of the root node for this index.
         /// @param indexId The id of the index.
-        function getIndexRoot(bytes32 indexId) constant returns (bytes32) {
+        function getIndexRoot(bytes32 indexId) public view returns (bytes32) {
             return index_lookup[indexId].root;
         }
 
         /// @dev Retrieve the index id for the node.
         /// @param nodeId The id for the node
-        function getNodeIndexId(bytes32 nodeId) constant returns (bytes32) {
+        function getNodeIndexId(bytes32 nodeId) public view returns (bytes32) {
             return node_to_index[nodeId];
         }
 
         /// @dev Retrieve the value of the node.
         /// @param nodeId The id for the node
-        function getNodeValue(bytes32 nodeId) constant returns (int) {
+        function getNodeValue(bytes32 nodeId) public view returns (int) {
             return GroveLib.getNodeValue(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
         /// @dev Retrieve the height of the node.
         /// @param nodeId The id for the node
-        function getNodeHeight(bytes32 nodeId) constant returns (uint) {
+        function getNodeHeight(bytes32 nodeId) public view returns (uint) {
             return GroveLib.getNodeHeight(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
         /// @dev Retrieve the parent id of the node.
         /// @param nodeId The id for the node
-        function getNodeParent(bytes32 nodeId) constant returns (bytes32) {
+        function getNodeParent(bytes32 nodeId) public view returns (bytes32) {
             return GroveLib.getNodeParent(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
         /// @dev Retrieve the left child id of the node.
         /// @param nodeId The id for the node
-        function getNodeLeftChild(bytes32 nodeId) constant returns (bytes32) {
+        function getNodeLeftChild(bytes32 nodeId) public view returns (bytes32) {
             return GroveLib.getNodeLeftChild(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
         /// @dev Retrieve the right child id of the node.
         /// @param nodeId The id for the node
-        function getNodeRightChild(bytes32 nodeId) constant returns (bytes32) {
+        function getNodeRightChild(bytes32 nodeId) public view returns (bytes32) {
             return GroveLib.getNodeRightChild(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
@@ -80,7 +82,7 @@ contract Grove {
          *  one.  Returns 0x0 if there is no previous node.
          */
         /// @param nodeId The id for the node
-        function getPreviousNode(bytes32 nodeId) constant returns (bytes32) {
+        function getPreviousNode(bytes32 nodeId) public view returns (bytes32) {
             return GroveLib.getPreviousNode(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
@@ -88,7 +90,7 @@ contract Grove {
          *  one.  Returns 0x0 if there is no previous node.
          */
         /// @param nodeId The id for the node
-        function getNextNode(bytes32 nodeId) constant returns (bytes32) {
+        function getNextNode(bytes32 nodeId) public view returns (bytes32) {
             return GroveLib.getNextNode(index_lookup[node_to_index[nodeId]], node_id_lookup[nodeId]);
         }
 
@@ -113,7 +115,7 @@ contract Grove {
         /// @dev Query whether a node exists within the specified index for the unique identifier.
         /// @param indexId The id for the index.
         /// @param id The unique identifier of the data element.
-        function exists(bytes32 indexId, bytes32 id) constant returns (bool) {
+        function exists(bytes32 indexId, bytes32 id) public view returns (bool) {
             return GroveLib.exists(index_lookup[indexId], id);
         }
 
@@ -133,7 +135,7 @@ contract Grove {
         /** @param operator One of '>', '>=', '<', '<=', '==' to specify what
          *  type of comparison operator should be used.
          */
-        function query(bytes32 indexId, bytes2 operator, int value) constant returns (bytes32) {
+        function query(bytes32 indexId, bytes2 operator, int value) public view returns (bytes32) {
                 return GroveLib.query(index_lookup[indexId], operator, value);
         }
 }

--- a/contracts/api.sol
+++ b/contracts/api.sol
@@ -1,34 +1,36 @@
+pragma solidity ^0.4.18;
+
 contract GroveAPI {
         /*
          *  Shortcuts
          */
-        function getIndexId(address ownerAddress, bytes32 indexName) constant returns (bytes32);
-        function getNodeId(bytes32 indexId, bytes32 id) constant returns (bytes32);
+        function getIndexId(address ownerAddress, bytes32 indexName) public view returns (bytes32);
+        function getNodeId(bytes32 indexId, bytes32 id) public view returns (bytes32);
 
         /*
          *  Node and Index API
          */
-        function getIndexName(bytes32 indexId) constant returns (bytes32);
-        function getIndexRoot(bytes32 indexId) constant returns (bytes32);
-        function getNodeId(bytes32 nodeId) constant returns (bytes32);
-        function getNodeIndexId(bytes32 nodeId) constant returns (bytes32);
-        function getNodeValue(bytes32 nodeId) constant returns (int);
-        function getNodeHeight(bytes32 nodeId) constant returns (uint);
-        function getNodeParent(bytes32 nodeId) constant returns (bytes32);
-        function getNodeLeftChild(bytes32 nodeId) constant returns (bytes32);
-        function getNodeRightChild(bytes32 nodeId) constant returns (bytes32);
+        function getIndexName(bytes32 indexId) public view returns (bytes32);
+        function getIndexRoot(bytes32 indexId) public view returns (bytes32);
+        function getNodeId(bytes32 nodeId) public view returns (bytes32);
+        function getNodeIndexId(bytes32 nodeId) public view returns (bytes32);
+        function getNodeValue(bytes32 nodeId) public view returns (int);
+        function getNodeHeight(bytes32 nodeId) public view returns (uint);
+        function getNodeParent(bytes32 nodeId) public view returns (bytes32);
+        function getNodeLeftChild(bytes32 nodeId) public view returns (bytes32);
+        function getNodeRightChild(bytes32 nodeId) public view returns (bytes32);
 
         /*
          *  Traversal
          */
-        function getNextNode(bytes32 nodeId) constant returns (bytes32);
-        function getPreviousNode(bytes32 nodeId) constant returns (bytes32);
+        function getNextNode(bytes32 nodeId) public view returns (bytes32);
+        function getPreviousNode(bytes32 nodeId) public view returns (bytes32);
 
         /*
          *  Insert and Query API
          */
         function insert(bytes32 indexName, bytes32 id, int value) public;
         function query(bytes32 indexId, bytes2 operator, int value) public returns (bytes32);
-        function exists(bytes32 indexId, bytes32 id) constant returns (bool);
+        function exists(bytes32 indexId, bytes32 id) public view returns (bool);
         function remove(bytes32 indexName, bytes32 id) public;
 }

--- a/libraries/GroveLib.sol
+++ b/libraries/GroveLib.sol
@@ -325,10 +325,10 @@ library GroveLib {
                 parent = index.nodes[nodeToDelete.parent];
 
                 if (parent.left == nodeToDelete.id) {
-                    parent.left = 0x0;
+                    delete parent.left;
                 }
                 if (parent.right == nodeToDelete.id) {
-                    parent.right = 0x0;
+                    delete parent.right;
                 }
 
                 // keep note of where the rebalancing should begin.
@@ -337,16 +337,16 @@ library GroveLib {
             else {
                 // This is both a leaf node and the root node, so we need to
                 // unset the root node pointer.
-                index.root = 0x0;
+                delete index.root;
             }
 
             // Now we zero out all of the fields on the nodeToDelete.
-            nodeToDelete.id = 0x0;
-            nodeToDelete.value = 0;
-            nodeToDelete.parent = 0x0;
-            nodeToDelete.left = 0x0;
-            nodeToDelete.right = 0x0;
-            nodeToDelete.height = 0;
+            delete nodeToDelete.id;
+            delete nodeToDelete.value;
+            delete nodeToDelete.parent;
+            delete nodeToDelete.left;
+            delete nodeToDelete.right;
+            delete nodeToDelete.height;
 
             // Walk back up the tree rebalancing
             if (rebalanceOrigin != 0x0) {
@@ -568,7 +568,7 @@ library GroveLib {
             newRoot.parent = originalRoot.parent;
 
             // The original root needs to have it's right child nulled out.
-            originalRoot.right = 0x0;
+            delete originalRoot.right;
 
             if (originalRoot.parent != 0x0) {
                 // If there is a parent node, it needs to now point downward at
@@ -622,7 +622,7 @@ library GroveLib {
             newRoot.parent = originalRoot.parent;
 
             // Null out the originalRoot.left
-            originalRoot.left = 0x0;
+            delete originalRoot.left;
 
             if (originalRoot.parent != 0x0) {
                 // If the node has a parent, update the correct child to point

--- a/libraries/GroveLib.sol
+++ b/libraries/GroveLib.sol
@@ -1,3 +1,5 @@
+pragma solidity ^0.4.18;
+
 // Grove v0.3
 
 
@@ -23,7 +25,7 @@ library GroveLib {
                 uint height;
         }
 
-        function max(uint a, uint b) internal returns (uint) {
+        function max(uint a, uint b) internal pure returns (uint) {
             if (a >= b) {
                 return a;
             }
@@ -36,49 +38,49 @@ library GroveLib {
         /// @dev Retrieve the unique identifier for the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeId(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getNodeId(Index storage index, bytes32 id) public view returns (bytes32) {
             return index.nodes[id].id;
         }
 
         /// @dev Retrieve the value for the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeValue(Index storage index, bytes32 id) constant returns (int) {
+        function getNodeValue(Index storage index, bytes32 id) public view returns (int) {
             return index.nodes[id].value;
         }
 
         /// @dev Retrieve the height of the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeHeight(Index storage index, bytes32 id) constant returns (uint) {
+        function getNodeHeight(Index storage index, bytes32 id) public view returns (uint) {
             return index.nodes[id].height;
         }
 
         /// @dev Retrieve the parent id of the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeParent(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getNodeParent(Index storage index, bytes32 id) public view returns (bytes32) {
             return index.nodes[id].parent;
         }
 
         /// @dev Retrieve the left child id of the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeLeftChild(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getNodeLeftChild(Index storage index, bytes32 id) public view returns (bytes32) {
             return index.nodes[id].left;
         }
 
         /// @dev Retrieve the right child id of the node.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNodeRightChild(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getNodeRightChild(Index storage index, bytes32 id) public view returns (bytes32) {
             return index.nodes[id].right;
         }
 
         /// @dev Retrieve the node id of the next node in the tree.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getPreviousNode(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getPreviousNode(Index storage index, bytes32 id) public view returns (bytes32) {
             Node storage currentNode = index.nodes[id];
 
             if (currentNode.id == 0x0) {
@@ -125,7 +127,7 @@ library GroveLib {
         /// @dev Retrieve the node id of the previous node in the tree.
         /// @param index The index that the node is part of.
         /// @param id The id for the node to be looked up.
-        function getNextNode(Index storage index, bytes32 id) constant returns (bytes32) {
+        function getNextNode(Index storage index, bytes32 id) public view returns (bytes32) {
             Node storage currentNode = index.nodes[id];
 
             if (currentNode.id == 0x0) {
@@ -186,9 +188,6 @@ library GroveLib {
                     remove(index, id);
                 }
 
-                uint leftHeight;
-                uint rightHeight;
-
                 bytes32 previousNodeId = 0x0;
 
                 if (index.root == 0x0) {
@@ -232,7 +231,7 @@ library GroveLib {
         /// @dev Checks whether a node for the given unique identifier exists within the given index.
         /// @param index The index that should be searched
         /// @param id The unique identifier of the data element to check for.
-        function exists(Index storage index, bytes32 id) constant returns (bool) {
+        function exists(Index storage index, bytes32 id) public view returns (bool) {
             return (index.nodes[id].height > 0);
         }
 
@@ -361,7 +360,7 @@ library GroveLib {
         bytes2 constant LTE = "<=";
         bytes2 constant EQ = "==";
 
-        function _compare(int left, bytes2 operator, int right) internal returns (bool) {
+        function _compare(int left, bytes2 operator, int right) internal pure returns (bool) {
             if (operator == GT) {
                 return (left > right);
             }
@@ -379,10 +378,10 @@ library GroveLib {
             }
 
             // Invalid operator.
-            throw;
+            revert();
         }
 
-        function _getMaximum(Index storage index, bytes32 id) internal returns (int) {
+        function _getMaximum(Index storage index, bytes32 id) internal view returns (int) {
                 Node storage currentNode = index.nodes[id];
 
                 while (true) {
@@ -393,7 +392,7 @@ library GroveLib {
                 }
         }
 
-        function _getMinimum(Index storage index, bytes32 id) internal returns (int) {
+        function _getMinimum(Index storage index, bytes32 id) internal view returns (int) {
                 Node storage currentNode = index.nodes[id];
 
                 while (true) {
@@ -414,7 +413,8 @@ library GroveLib {
         /** @param operator One of '>', '>=', '<', '<=', '==' to specify what
          *  type of comparison operator should be used.
          */
-        function query(Index storage index, bytes2 operator, int value) public returns (bytes32) {
+        function query(Index storage index, bytes2 operator, int value)
+        public view returns (bytes32) {
                 bytes32 rootNodeId = index.root;
                 
                 if (rootNodeId == 0x0) {
@@ -541,7 +541,7 @@ library GroveLib {
             }
         }
 
-        function _getBalanceFactor(Index storage index, bytes32 id) internal returns (int) {
+        function _getBalanceFactor(Index storage index, bytes32 id) internal view returns (int) {
                 Node storage node = index.nodes[id];
 
                 return int(index.nodes[node.left].height) - int(index.nodes[node.right].height);
@@ -559,7 +559,7 @@ library GroveLib {
             if (originalRoot.right == 0x0) {
                 // Cannot rotate left if there is no right originalRoot to rotate into
                 // place.
-                throw;
+                revert();
             }
 
             // The right child is the new root, so it gets the original
@@ -613,7 +613,7 @@ library GroveLib {
             if (originalRoot.left == 0x0) {
                 // Cannot rotate right if there is no left node to rotate into
                 // place.
-                throw;
+                revert();
             }
 
             // The left child is taking the place of node, so we update it's


### PR DESCRIPTION
This PR has two commits. The first fixes a slew of compiler warnings that get emitted compiling this on newer versions of solc. It does thing like explicitly declare functions as public which had previously been implicitly public, and change `constant` functions to `pure` and `view` as appropriate. There were also some unused variable warnings, and I deleted those variables.

The second commit replaces instances where storage was nulled using `x = 0` to `delete x`, which I find to be more legible.

I did verify that this compiles, but I don't know how to run the tests in this repo. So definitely check on that if you want to consider merging this at all.